### PR TITLE
Fix server to report actual bound address

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -52,11 +52,14 @@ pub async fn start_server(config: AppConfig, metrics_handle: PrometheusHandle, r
             std::process::exit(1);
         }
     };
+    
+    // Useful when passing port 0 (which means "pick an available port").
+    let local_addr = listener.local_addr().unwrap();
 
     let app = create_app(config, Some(metrics_handle), registry).await;
 
-    println!("🚀 VidaiMock is running at http://{}", addr);
-    tracing::info!("Listening on {}", addr);
+    println!("🚀 VidaiMock is running at http://{}", local_addr);
+    tracing::info!("Listening on {}", local_addr);
     
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())


### PR DESCRIPTION
## Summary
- Use `listener.local_addr()` instead of the configured `addr` when logging the server address
- This correctly reports the actual bound address, which is important when using port 0 (OS-assigned port)

## Test plan
- [x] `cargo build` passes
- [x] Manual test: ran with `--port 0` and confirmed the logged port matches the actual bound port

```
🚀 VidaiMock is running at http://0.0.0.0:56989
INFO vidaimock::server: Listening on 0.0.0.0:56989
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)